### PR TITLE
Improve OCR using RapidOCR and fuzzy skill matching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+rapidocr-onnxruntime
+rapidfuzz

--- a/testout.csv
+++ b/testout.csv
@@ -1,3 +1,3 @@
 Speed,Stamina,Power,Guts,Wit,Skills
-1089,842,542,320,456,Breath of Fresh Air|Early Lead|Escape Artist|Flashy☆Landing|Front Runner Corners|Leader's Pride|Professor of Curvature|Straightaway Adept
-843,1004,487,348,541,Escape Artist|Leader's Pride|Professor of Curvature
+1089,842,542,320,456,Flashy☆Landing|Professor of Curvature|Straightaway Adept|Breath of Fresh Air|Early Lead|Escape Artist|Front Runner Corners ○|Leader's Pride
+843,1004,487,348,541,Flashy☆Landing|Victoria Por Plancha ☆|Maverick ◎|Professor of Curvature|Corner Recovery ○|Taking the Lead|Escape Artist|Final Push|Leader's Pride|Moxie


### PR DESCRIPTION
## Summary
- Switch OCR engine from Tesseract to RapidOCR (ONNX runtime) for better accuracy
- Add fuzzy skill matching and ordering to capture stars/circles and maintain top-to-bottom,left-to-right order
- Include requirements file and update sample output

## Testing
- `python uma_ocr_to_csv.py 1.JPG 2.JPG testout.csv`


------
https://chatgpt.com/codex/tasks/task_e_688fcc43eb148329acf178f757747989