### PR TITLE
Load skill names from separate file

### DIFF
--- a/extract_skill_names.py
+++ b/extract_skill_names.py
@@ -1,0 +1,31 @@
+"""Extract skill names from the provided HTML file.
+
+Usage:
+    python extract_skill_names.py [input_html] [output_txt]
+"""
+import html
+import pathlib
+import re
+import sys
+
+def extract(html_file: pathlib.Path) -> list[str]:
+    text = html_file.read_text(encoding="utf-8", errors="ignore")
+    names = re.findall(r'<span[^>]*class="skillName"[^>]*>(.*?)</span>', text, re.DOTALL)
+    skills = {
+        html.unescape(name.strip())
+        for name in names
+        if name.strip() and not name.strip().endswith("CC")
+    }
+    return sorted(skills)
+
+def main() -> None:
+    html_path = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else pathlib.Path("Uma Musume_ Pretty Derby race simulator.htm")
+    out_path = pathlib.Path(sys.argv[2]) if len(sys.argv) > 2 else pathlib.Path("skill_names.txt")
+    skills = extract(html_path)
+    with open(out_path, "w", encoding="utf-8") as f:
+        for s in skills:
+            f.write(s + "\n")
+    print(f"wrote {len(skills)} skills to {out_path}")
+
+if __name__ == "__main__":
+    main()

--- a/skill_names.txt
+++ b/skill_names.txt
@@ -1,0 +1,348 @@
+A Small Breather
+Acceleration
+Adrenaline Rush
+After-School Stroll
+All-Seeing Eyes
+Anchors Aweigh!
+Battle Formation
+Beeline Burst
+Behold Thine Emperor's Divine Might
+Big-Sisterly
+Blazing Pride
+Blinding Flash
+Blue Rose Closer
+Breath of Fresh Air
+Calm and Collected
+Calm in a Crowd
+Center Stage
+Certain Victory
+Changing Gears
+Chukyo Racecourse ×
+Chukyo Racecourse ○
+Chukyo Racecourse ◎
+Clairvoyance
+Cloudy Days ○
+Cloudy Days ◎
+Competitive Spirit ○
+Competitive Spirit ◎
+Concentration
+Cooldown
+Corner Acceleration ×
+Corner Acceleration ○
+Corner Adept ×
+Corner Adept ○
+Corner Connoisseur
+Corner Recovery ×
+Corner Recovery ○
+Countermeasure
+Crusader
+Cut and Drive!
+Dazzling Disorientation
+Deep Breaths
+Defeatist
+Determined Descent
+Disorient
+Dodging Danger
+Dominator
+Early Lead
+Encroaching Shadow
+End Closer Corners ○
+End Closer Corners ◎
+End Closer Savvy ○
+End Closer Savvy ◎
+End Closer Straightaways ○
+End Closer Straightaways ◎
+Escape Artist
+Extra Tank
+Fall Runner ×
+Fall Runner ○
+Fall Runner ◎
+Fast & Furious
+Fast-Paced
+Fighter
+Final Push
+Firm Conditions ×
+Firm Conditions ○
+Firm Conditions ◎
+Flashy☆Landing
+Flustered End Closers
+Flustered Front Runners
+Flustered Late Surgers
+Flustered Pace Chasers
+Focus
+Frenzied End Closers
+Frenzied Front Runners
+Frenzied Late Surgers
+Frenzied Pace Chasers
+Front Runner Corners ○
+Front Runner Corners ◎
+Front Runner Savvy ○
+Front Runner Savvy ◎
+Front Runner Straightaways ○
+Front Runner Straightaways ◎
+Fukushima Racecourse ×
+Fukushima Racecourse ○
+Fukushima Racecourse ◎
+Furious Feat
+G00 1st. F∞;
+G1 Averseness
+Gap Closer
+Gatekept
+Genius x Bakushin = Victory
+Go with the Flow
+Go-Home Specialist
+Gourmand
+Greed for Speed
+Groundwork
+Hakodate Racecourse ×
+Hakodate Racecourse ○
+Hakodate Racecourse ◎
+Hanshin Racecourse ×
+Hanshin Racecourse ○
+Hanshin Racecourse ◎
+Hard Worker
+Hawkeye
+Hesitant End Closers
+Hesitant Front Runners
+Hesitant Late Surgers
+Hesitant Pace Chasers
+Highlander
+Homestretch Haste
+Huge Lead
+Hydrate
+I Can See Right Through You
+I See Victory in My Future!
+Illusionist
+In Body and Mind
+Indomitable
+Innate Experience
+Inner Post Averseness
+Inner Post Proficiency ○
+Inner Post Proficiency ◎
+Inside Scoop
+Intense Gaze
+Intimidate
+Iron Will
+It's On!
+Just a Little Farther!
+Keen Eye
+Keeping the Lead
+Killer Tunes
+Kokura Racecourse ×
+Kokura Racecourse ○
+Kokura Racecourse ◎
+Kyoto Racecourse ×
+Kyoto Racecourse ○
+Kyoto Racecourse ◎
+Lane Legerdemain
+Late Surger Corners ○
+Late Surger Savvy ○
+Late Surger Savvy ◎
+Late Surger Straightaways ○
+Late Surger Straightaways ◎
+Later Surger Corners ◎
+Lay Low
+Leader's Pride
+Left-Handed ×
+Left-Handed ○
+Left-Handed ◎
+Legacy of the Strong
+Let's Pump Some Iron!
+Levelheaded
+Lightning Step
+Lone Wolf
+Long Corners ○
+Long Corners ◎
+Long Shot ○
+Long Shot ◎
+Long Straightaways ○
+Long Straightaways ◎
+Lucky Seven
+Masterful Gambit
+Maverick ○
+Maverick ◎
+Medium Corners ○
+Medium Corners ◎
+Medium Straightaways ○
+Medium Straightaways ◎
+Meticulous Measures
+Mile Corners ○
+Mile Corners ◎
+Mile Maven
+Mile Straightaways ○
+Mile Straightaways ◎
+Miraculous Step
+Moxie
+Murmur
+Mystifying Murmur
+Nakayama Racecourse ×
+Nakayama Racecourse ○
+Nakayama Racecourse ◎
+Niigata Racecourse ×
+Niigata Racecourse ○
+Niigata Racecourse ◎
+Nimble Navigator
+No Stopping Me!
+Non-Standard Distance ×
+Non-Standard Distance ○
+Non-Standard Distance ◎
+Oi Racecourse ×
+Oi Racecourse ○
+Oi Racecourse ◎
+On Your Left!
+Opening Gambit
+Our Ticket to Win!
+Outer Post Averseness
+Outer Post Proficiency ○
+Outer Post Proficiency ◎
+Outer Swell
+Overwhelming Pressure
+Pace Chaser Corners ○
+Pace Chaser Corners ◎
+Pace Chaser Savvy ○
+Pace Chaser Savvy ◎
+Pace Chaser Straightaways ○
+Pace Chaser Straightaways ◎
+Pace Strategy
+Packphobia
+Paddock Fright
+Passing Pro
+Perfect Prep!
+Petrifying Gaze
+Plan X
+Playtime's Over!
+Position Pilfer
+Preferred Position
+Prepared to Pass
+Pressure
+Prideful King
+Productive Plan
+Professor of Curvature
+Prudent Positioning
+Pure Heart
+Race Planner
+Rainy Days ×
+Rainy Days ○
+Rainy Days ◎
+Ramp Revulsion
+Ramp Up
+Reckless
+Red Shift/LP1211-M
+Reignition
+Relax
+Resplendent Red Ace
+Restart
+Restless
+Right-Handed ×
+Right-Handed ○
+Right-Handed ◎
+Rising Dragon
+Rosy Outlook
+Running Idle
+Rushing Gale!
+Sapporo Racecourse ×
+Sapporo Racecourse ○
+Sapporo Racecourse ◎
+Second Wind
+Serenity
+Shake It Out
+Sharp Gaze
+Shatterproof
+Shifting Gears
+Shooting Star
+Shooting for Victory!
+Shrewd Step
+Sky-High Teio Step
+Sleeping Lion
+Slick Surge
+Slipstream
+Smoke Screen
+Snowy Days ○
+Snowy Days ◎
+Soft Step
+Speed Eater
+Speed Star
+Spring Runner ×
+Spring Runner ○
+Spring Runner ◎
+Sprint Corners ○
+Sprint Corners ◎
+Sprint Straightaways ○
+Sprint Straightaways ◎
+Sprinting Gear
+Staggering Lead
+Stamina Eater
+Stamina Siphon
+Stamina to Spare
+Standard Distance ×
+Standard Distance ○
+Standard Distance ◎
+Standing By
+Steadfast
+Step on the Gas!
+Stop Right There!
+Straight Descent
+Straightaway Acceleration
+Straightaway Adept
+Straightaway Recovery
+Straightaway Spurt
+Strategist
+Studious
+Sturm und Drang
+Subdued End Closers
+Subdued Front Runners
+Subdued Late Surgers
+Subdued Pace Chasers
+Summer Runner ×
+Summer Runner ○
+Summer Runner ◎
+Sunny Days ○
+Sunny Days ◎
+Super Lucky Seven
+Super-Duper Climax
+Swinging Maestro
+Sympathy
+Tactical Tweak
+Tail Held High
+Taking the Lead
+Target in Sight ○
+Target in Sight ◎
+Technician
+Tether
+The Bigger Picture
+The Coast Is Clear!
+The Duty of Dignity Calls
+The View from the Lead Is Mine!
+This Dance Is for Vittoria!
+Thunderbolt Step
+Tokyo Racecourse ×
+Tokyo Racecourse ○
+Tokyo Racecourse ◎
+Trackblazer
+Trick (Front)
+Trick (Rear)
+Triple 7s
+Triumphant Pulse
+Turbo Sprint
+U=ma2
+Uma Stan
+Unrestrained
+Unruffled
+Unyielding
+Unyielding Spirit
+Up-Tempo
+Updrafters
+Vanguard Spirit
+Victoria por plancha ☆
+Wait-and-See
+Wallflower
+Watchful Eye
+Wet Conditions ×
+Wet Conditions ○
+Wet Conditions ◎
+Where There's a Will, There's a Way
+Winter Runner ×
+Winter Runner ○
+Winter Runner ◎
+You've Got No Shot
+∴win Q.E.D.

--- a/uma_ocr_to_csv.py
+++ b/uma_ocr_to_csv.py
@@ -3,28 +3,23 @@ import re
 import sys
 from rapidocr_onnxruntime import RapidOCR
 from rapidfuzz import process, fuzz
+from pathlib import Path
 
-# Canonical skill names we expect in the samples
-CANONICAL_SKILLS = [
-    "Flashy☆Landing",
-    "Professor of Curvature",
-    "Straightaway Adept",
-    "Breath of Fresh Air",
-    "Early Lead",
-    "Escape Artist",
-    "Front Runner Corners ○",
-    "Leader's Pride",
-    "Victoria Por Plancha ☆",
-    "Maverick ◎",
-    "Corner Recovery ○",
-    "Taking the Lead",
-    "Final Push",
-    "Moxie",
-]
+
+def _load_skills() -> list[str]:
+    """Load canonical skill names from the skills file."""
+    skill_file = Path(__file__).with_name("skill_names.txt")
+    with open(skill_file, encoding="utf-8") as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+CANONICAL_SKILLS = _load_skills()
+
 
 # Normalization helper
 def _norm(s: str) -> str:
     return re.sub(r"[^a-z0-9]", "", s.lower())
+
 
 CANONICAL_MAP = {_norm(name): name for name in CANONICAL_SKILLS}
 


### PR DESCRIPTION
## Summary
- Read canonical skill names from `skill_names.txt` instead of a hard-coded list in the OCR script.
- Add helper `extract_skill_names.py` to generate the skills file from the provided HTML.
- Include generated `skill_names.txt` with full list of skill names.

## Testing
- `python extract_skill_names.py 'Uma Musume_ Pretty Derby race simulator.htm' skill_names.txt`
- `python uma_ocr_to_csv.py 1.JPG 2.JPG out.csv`


------
https://chatgpt.com/codex/tasks/task_e_688fda06cdc08329bf1bb3f6137389d5