### PR TITLE
Load skills from shared uma-tools data

### DIFF
--- a/uma_ocr_to_csv.py
+++ b/uma_ocr_to_csv.py
@@ -12,6 +12,10 @@ import numpy as np
 from dotenv import load_dotenv
 from rapidocr_onnxruntime import RapidOCR
 from rapidfuzz import process, fuzz
+import json
+
+# Reuse the skill name data source from uma_csv_to_url
+from uma_csv_to_url import REPO_URL_TOOLS, TOOLS_DIR, ensure_repo
 
 
 ENV_PATH = Path(__file__).with_name(".env")
@@ -27,15 +31,17 @@ logger.debug("Environment loaded from %s with log level %s", ENV_PATH, LOG_LEVEL
 
 
 def _load_skills() -> list[str]:
-    """Load canonical skill names from the skills file."""
-    skill_file = Path(__file__).with_name("skill_names.txt")
+    """Load canonical skill names from the uma-tools repository."""
+    ensure_repo(REPO_URL_TOOLS, TOOLS_DIR)
+    skill_file = TOOLS_DIR / "umalator-global" / "skillnames.json"
     logger.debug("Loading skills from %s", skill_file)
     try:
         with open(skill_file, encoding="utf-8") as f:
-            skills = [line.strip() for line in f if line.strip()]
+            data = json.load(f)
     except FileNotFoundError:
         logger.error("Skill file not found: %s", skill_file)
         return []
+    skills = [names[0] for names in data.values() if names]
     logger.info("Loaded %d skills", len(skills))
     return skills
 


### PR DESCRIPTION
## Summary
- Load skill names for OCR from the same `skillnames.json` used by `uma_csv_to_url.py`
- Remove dependency on local `skill_names.txt`

## Testing
- `python -m py_compile uma_ocr_to_csv.py`
- `python -m py_compile uma_csv_to_url.py`


------
https://chatgpt.com/codex/tasks/task_e_6899124cea388329a14a8ae35b29de12