### PR TITLE
Add runner name extraction and share link support

### DIFF
--- a/uma_csv_to_url.py
+++ b/uma_csv_to_url.py
@@ -56,6 +56,7 @@ LOCAL_WEB_LOGGING = os.getenv("LOCAL_WEB_LOGGING", "").strip().lower() == "true"
 
 @dataclass
 class Horse:
+    name: str
     speed: int
     stamina: int
     power: int
@@ -70,6 +71,7 @@ class Horse:
 
     def to_json(self) -> Dict:
         return {
+            "name": self.name,
             "outfitId": self.outfitId,
             "speed": self.speed,
             "stamina": self.stamina,
@@ -104,7 +106,7 @@ def load_skill_mapping() -> Dict[str, str]:
 
 
 def parse_horse(row: Dict[str, str], skill_map: Dict[str, str]) -> Horse:
-    skills = []
+    skills: List[str] = []
     for name in row.get("Skills", "").split("|"):
         key = name.strip().lower()
         if not key:
@@ -113,6 +115,7 @@ def parse_horse(row: Dict[str, str], skill_map: Dict[str, str]) -> Horse:
         if skill_id:
             skills.append(skill_id)
     return Horse(
+        name=row.get("Name", ""),
         speed=int(row.get("Speed", 0) or 0),
         stamina=int(row.get("Stamina", 0) or 0),
         power=int(row.get("Power", 0) or 0),
@@ -203,7 +206,7 @@ def main(argv: List[str]) -> int:
         summary = ", ".join(
             f"{k}:{row.get(k, '')}" for k in ["Speed", "Stamina", "Power", "Guts", "Wit"]
         )
-        print(f"{idx}: {summary}")
+        print(f"{idx}: {row.get('Name', '')} | {summary}")
 
     def select(prompt: str) -> int | None:
         value = input(prompt)


### PR DESCRIPTION
## Summary
- detect runner names via OCR and write them as the first CSV column
- include runner names when generating UmaLator share hashes and server listings

## Testing
- `python -m py_compile uma_ocr_to_csv.py uma_csv_to_url.py`
- `python uma_ocr_to_csv.py`
- `python - <<'PY'
import csv, json, base64, urllib.parse, gzip
from uma_csv_to_url import csv_to_hash
with open('data/runners.csv', newline='', encoding='utf-8') as f:
    rows=list(csv.DictReader(f))
share_hash = csv_to_hash(rows[:2])
print('hash length', len(share_hash))
print('preview', share_hash[:60])
# decode to verify names
payload = json.loads(gzip.decompress(base64.b64decode(urllib.parse.unquote(share_hash))).decode('utf-8'))
print('names', payload['uma1']['name'], '/', payload['uma2']['name'])
PY`
- `python uma_csv_to_url.py <<'EOF'
quit
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68991a7d13b483298ce89a366c3b288a