### PR TITLE
Add GUI runner selector

### DIFF
--- a/uma_csv_to_url.py
+++ b/uma_csv_to_url.py
@@ -285,7 +285,7 @@ def run_gui(
                     break
                 widget = widget.master
 
-        canvas.bind_all("<MouseWheel>", on_mousewheel)
+        canvas.bind_all("<MouseWheel>", on_mousewheel, add="+")
 
         selected_idx: List[int | None] = [None]
         selected_frame: List[tk.Frame | None] = [None]


### PR DESCRIPTION
## Summary
- provide a Tkinter GUI for selecting two runners
- automatically open UmaLator with chosen pair
- shut down web server when GUI closes

## Testing
- `python -m py_compile uma_csv_to_url.py`


------
https://chatgpt.com/codex/tasks/task_e_68994981f3b48329b734d2148aacdac3