### PR TITLE
Add GUI for selecting runners

### DIFF
--- a/uma_csv_to_url.py
+++ b/uma_csv_to_url.py
@@ -28,6 +28,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Dict
 
+import tkinter as tk
+from tkinter import ttk, messagebox
+
 from dotenv import load_dotenv
 from rapidfuzz import process, fuzz
 
@@ -254,6 +257,93 @@ def start_server() -> tuple[http.server.ThreadingHTTPServer, threading.Thread, i
     thread.start()
     return httpd, thread, httpd.server_port
 
+def _build_tree(parent: ttk.Frame, runners: List[Dict[str, str]]) -> ttk.Treeview:
+    """Return a tree view listing all runner information."""
+    columns = ("Title", "Speed", "Stamina", "Power", "Guts", "Wit", "Skills")
+    tree = ttk.Treeview(parent, columns=columns, show="headings", selectmode="browse")
+    for col in columns:
+        tree.heading(col, text=col)
+    widths = {"Title": 180, "Skills": 260}
+    for col in columns:
+        tree.column(col, width=widths.get(col, 60), anchor=tk.CENTER)
+    for idx, row in enumerate(runners):
+        title = f"{row.get('Epithet', '')} {row.get('Name', '')}".strip()
+        skills = row.get("Skills", "")
+        tree.insert(
+            "",
+            "end",
+            iid=str(idx),
+            values=(
+                title,
+                row.get("Speed", ""),
+                row.get("Stamina", ""),
+                row.get("Power", ""),
+                row.get("Guts", ""),
+                row.get("Wit", ""),
+                skills,
+            ),
+        )
+    scrollbar = ttk.Scrollbar(parent, orient="vertical", command=tree.yview)
+    tree.configure(yscrollcommand=scrollbar.set)
+    tree.grid(row=0, column=0, sticky="nsew")
+    scrollbar.grid(row=0, column=1, sticky="ns")
+    parent.rowconfigure(0, weight=1)
+    parent.columnconfigure(0, weight=1)
+    return tree
+
+
+def _launch_gui(
+    runners: List[Dict[str, str]],
+    httpd: http.server.ThreadingHTTPServer,
+    thread: threading.Thread,
+    port: int,
+) -> None:
+    """Display a GUI for selecting two runners and opening UmaLator."""
+
+    root = tk.Tk()
+    root.title("UmaLator Runner Selector")
+
+    left = ttk.Frame(root)
+    right = ttk.Frame(root)
+    left.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+    right.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+    tree1 = _build_tree(left, runners)
+    tree2 = _build_tree(right, runners)
+
+    def open_selected() -> None:
+        sel1 = tree1.selection()
+        sel2 = tree2.selection()
+        if not sel1 or not sel2:
+            messagebox.showerror("Selection error", "Select a runner in each list")
+            return
+        idx1 = int(sel1[0])
+        idx2 = int(sel2[0])
+        share_hash = csv_to_hash([runners[idx1], runners[idx2]])
+        url = f"http://127.0.0.1:{port}/index.html#{share_hash}"
+        try:
+            webbrowser.open_new_tab(url)
+        except Exception:
+            pass
+
+    button = ttk.Button(root, text="Open UmaLator", command=open_selected)
+    button.pack(fill=tk.X, pady=5)
+
+    def on_close() -> None:
+        httpd.shutdown()
+        root.destroy()
+
+    root.protocol("WM_DELETE_WINDOW", on_close)
+
+    def poll_server() -> None:
+        if not thread.is_alive():
+            root.destroy()
+        else:
+            root.after(1000, poll_server)
+
+    root.after(1000, poll_server)
+    root.mainloop()
+
 
 def main(argv: List[str]) -> int:
     data_dir = Path(__file__).with_name("data")
@@ -268,69 +358,9 @@ def main(argv: List[str]) -> int:
         print("Need at least two runners to compare")
         return 1
 
-    for idx, row in enumerate(runners, 1):
-        stats = ", ".join(
-            f"{k}: {row.get(k, '')}" for k in ["Speed", "Stamina", "Power", "Guts", "Wit"]
-        )
-        title = f"{row.get('Epithet', '')} {row.get('Name', '')}".strip()
-        print(f"{idx}. {title}")
-        print(stats)
-
-        skills = [s.strip() for s in row.get("Skills", "").split("|") if s.strip()]
-        col_width = 40
-        total_width = col_width * 2 + 5
-        print("Skills".center(total_width, "-"))
-        for i in range(0, len(skills), 2):
-            left = skills[i]
-            right = skills[i + 1] if i + 1 < len(skills) else ""
-            print(f"| {left:<{col_width}}| {right:<{col_width}}|")
-        print("-" * total_width)
-
-    def select(prompt: str) -> int | None:
-        value = input(prompt)
-        if value.strip().lower() == "quit":
-            return None
-        try:
-            idx = int(value) - 1
-        except ValueError:
-            print("Invalid selection")
-            return select(prompt)
-        if not (0 <= idx < len(runners)):
-            print("Selection out of range")
-            return select(prompt)
-        return idx
-
-    idx1 = select("Select runner 1: ")
-    if idx1 is None:
-        return 0
-    idx2 = select("Select runner 2: ")
-    if idx2 is None:
-        return 0
-
     httpd, thread, port = start_server()
     try:
-        share_hash = csv_to_hash([runners[idx1], runners[idx2]])
-        url = f"http://127.0.0.1:{port}/index.html#{share_hash}"
-        print(f"Umalator is now open with runners #{idx1+1} and #{idx2+1}.")
-        try:
-            webbrowser.open(url)
-        except Exception:
-            pass
-
-        while True:
-            idx1 = select("Select runner 1 (or 'quit'): ")
-            if idx1 is None:
-                break
-            idx2 = select("Select runner 2 (or 'quit'): ")
-            if idx2 is None:
-                break
-            share_hash = csv_to_hash([runners[idx1], runners[idx2]])
-            url = f"http://127.0.0.1:{port}/index.html#{share_hash}"
-            print(f"Umalator is now open with runners #{idx1+1} and #{idx2+1}.")
-            try:
-                webbrowser.open_new_tab(url)
-            except Exception:
-                pass
+        _launch_gui(runners, httpd, thread, port)
     finally:
         httpd.shutdown()
         thread.join()


### PR DESCRIPTION
## Summary
- replace CLI runner selection with a Tkinter GUI featuring two runner lists
- allow opening UmaLator in a browser tab for selected runners while keeping server and GUI synchronized

## Testing
- `timeout 5 xvfb-run -a python uma_csv_to_url.py`

------
https://chatgpt.com/codex/tasks/task_e_68994981f3b48329b734d2148aacdac3