### PR TITLE
Add licensing overview and AI code provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ Please review and comply with the licenses provided by those upstream projects (
 
 ## Code Generation
 
-Most of the source code in this repository was generated with the help of OpenAI's ChatGPT Codex and subsequently refined. The generated content has been reviewed to ensure alignment with the project's licensing obligations.
+Most of the source code in this repository was generated with the help of OpenAI's ChatGPT Codex and subsequently refined.
 


### PR DESCRIPTION
## Summary
- reference external repositories `uma-tools` and `uma-skill-tools` and note license compliance
- clarify that most code originated from OpenAI's ChatGPT Codex

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689949e43c888329a3f9cde2898a5794