### PR TITLE
Restrict non-9 skill override to first mapping entry

### DIFF
--- a/uma_csv_to_url.py
+++ b/uma_csv_to_url.py
@@ -104,11 +104,11 @@ def load_skill_mapping() -> Dict[str, str]:
         data = json.load(f)
     mapping: Dict[str, str] = {}
     for skill_id, names in data.items():
-        for name in names:
+        for i, name in enumerate(names):
             key = name.lower()
             existing = mapping.get(key)
             if existing is None or (
-                existing.startswith("9") and not skill_id.startswith("9")
+                i == 0 and existing.startswith("9") and not skill_id.startswith("9")
             ):
                 mapping[key] = skill_id
     return mapping


### PR DESCRIPTION
## Summary
- Ensure skill IDs starting with non-9 only override existing ones on the first name per skill

## Testing
- `python -m py_compile uma_csv_to_url.py`


------
https://chatgpt.com/codex/tasks/task_e_689bbf7006bc8329ab337c39e60ab849